### PR TITLE
fix: java.lang.ClassCastException on api level 15

### DIFF
--- a/app/src/main/java/uk/verscreative/materialsettings/SettingsExampleActivity.java
+++ b/app/src/main/java/uk/verscreative/materialsettings/SettingsExampleActivity.java
@@ -47,7 +47,7 @@ public class SettingsExampleActivity extends PreferenceActivity {
 
         AppBarLayout bar;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
             LinearLayout root = (LinearLayout) findViewById(android.R.id.list).getParent().getParent().getParent();
             bar = (AppBarLayout) LayoutInflater.from(this).inflate(R.layout.toolbar_settings, root, false);
             root.addView(bar, 0);


### PR DESCRIPTION
fix: java.lang.ClassCastException: android.widget.LinearLayout cannot be cast to android.widget.ListView on api level 15